### PR TITLE
feat: CLI for quick scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ dist
 
 *.lerna_backup
 _fixtures
+.temp

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ For example:
 }
 ```
 
+### Migration
+
+We provided an experimental cli tool to help you migrate from the legacy config to the new flat config.
+
+```bash
+# npm
+npx @ivanmaxlogiudice/eslint-config migrate
+
+# pnpm
+pnpm dlx @ivanmaxlogiudice/eslint-config migrate
+```
+
+Before running the migration, make sure to commit your changes first.
+
 ## VS Code support (auto fix)
 
 Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '../dist/cli.js'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "url": "git+https://github.com/ivanmaxlogiudice/eslint-config.git"
     },
     "files": [
+        "bin",
         "dist"
     ],
     "main": "./dist/index.js",
@@ -27,13 +28,14 @@
             "require": "./dist/index.cjs"
         }
     },
+    "bin": "./bin/index.js",
     "publishConfig": {
         "access": "public"
     },
     "scripts": {
-        "build": "tsup src/index.ts --format esm,cjs --clean --dts",
-        "stub": "tsup src/index.ts --format esm",
-        "dev": "tsup src/index.ts --format esm,cjs --watch & eslint-flat-config-viewer",
+        "build": "tsup --format esm,cjs --clean --dts",
+        "stub": "tsup --format esm",
+        "dev": "tsup --format esm,cjs --watch & eslint-flat-config-viewer",
         "lint": "pnpm run stub && eslint .",
         "prepack": "pnpm run build",
         "release": "bumpp && pnpm publish",
@@ -51,6 +53,8 @@
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "@unocss/eslint-plugin": "^0.57.2",
+        "cac": "^6.7.14",
+        "detect-indent": "^7.0.1",
         "eslint-config-flat-gitignore": "^0.1.1",
         "eslint-plugin-antfu": "^1.0.2",
         "eslint-plugin-eslint-comments": "^3.2.0",
@@ -70,15 +74,18 @@
         "globals": "^13.23.0",
         "jsonc-eslint-parser": "^2.4.0",
         "local-pkg": "^0.5.0",
+        "parse-gitignore": "^2.0.0",
+        "picocolors": "^1.0.0",
+        "prompts": "^2.4.2",
         "vue-eslint-parser": "^9.3.2",
         "yaml-eslint-parser": "^1.2.2"
     },
     "devDependencies": {
-        "@antfu/ni": "^0.21.8",
         "@stylistic/eslint-plugin-migrate": "^1.0.1",
         "@types/eslint": "^8.44.7",
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^20.9.0",
+        "@types/prompts": "^2.4.8",
         "bumpp": "^9.2.0",
         "eslint": "^8.53.0",
         "eslint-flat-config-viewer": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@unocss/eslint-plugin':
         specifier: ^0.57.2
         version: 0.57.2(eslint@8.53.0)(typescript@5.2.2)
+      cac:
+        specifier: ^6.7.14
+        version: 6.7.14
+      detect-indent:
+        specifier: ^7.0.1
+        version: 7.0.1
       eslint-config-flat-gitignore:
         specifier: ^0.1.1
         version: 0.1.1
@@ -83,6 +89,15 @@ importers:
       local-pkg:
         specifier: ^0.5.0
         version: 0.5.0
+      parse-gitignore:
+        specifier: ^2.0.0
+        version: 2.0.0
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.0.0
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
       vue-eslint-parser:
         specifier: ^9.3.2
         version: 9.3.2(eslint@8.53.0)
@@ -90,9 +105,6 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
     devDependencies:
-      '@antfu/ni':
-        specifier: ^0.21.8
-        version: 0.21.8
       '@stylistic/eslint-plugin-migrate':
         specifier: ^1.0.1
         version: 1.0.1(eslint@8.53.0)(typescript@5.2.2)
@@ -105,6 +117,9 @@ importers:
       '@types/node':
         specifier: ^20.9.0
         version: 20.9.0
+      '@types/prompts':
+        specifier: ^2.4.8
+        version: 2.4.8
       bumpp:
         specifier: ^9.2.0
         version: 9.2.0
@@ -149,11 +164,6 @@ packages:
     resolution: {integrity: sha512-LvxY21+ZhpuBf/aHeBUtGQhSEfad4PkNKXKvDOSvukaM3XVTfBhwmHX2EKwAsdq5DlfjbT3qqYyMiueBIO5iDQ==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0', pnpm: '>= 8.6.0'}
     dev: false
-
-  /@antfu/ni@0.21.8:
-    resolution: {integrity: sha512-90X8pU2szlvw0AJo9EZMbYc2eQKkmO7mAdC4tD4r5co2Mm56MT37MIG8EyB7p4WRheuzGxuLDxJ63mF6+Zajiw==}
-    hasBin: true
-    dev: true
 
   /@antfu/utils@0.7.6:
     resolution: {integrity: sha512-pvFiLP2BeOKA/ZOS6jxx4XhKzdVLHDhGlFEaZ2flWWYf2xOqVniqpk38I04DFRyz+L0ASggl7SkItTc+ZLju4w==}
@@ -611,6 +621,13 @@ packages:
   /@types/normalize-package-data@2.4.3:
     resolution: {integrity: sha512-ehPtgRgaULsFG8x0NeYJvmyH1hmlfsNLujHe9dQEia/7MAJYdzMSi19JtchUHjmBA6XC/75dK55mzZH+RyieSg==}
     dev: false
+
+  /@types/prompts@2.4.8:
+    resolution: {integrity: sha512-fPOEzviubkEVCiLduO45h+zFHB0RZX8tFt3C783sO5cT7fUXf3EEECpD26djtYdh4Isa9Z9tasMQuZnYPtvYzw==}
+    dependencies:
+      '@types/node': 20.9.0
+      kleur: 3.0.3
+    dev: true
 
   /@types/semver@7.5.4:
     resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
@@ -1293,6 +1310,11 @@ packages:
   /destr@2.0.2:
     resolution: {integrity: sha512-65AlobnZMiCET00KaFFjUefxDX0khFA/E4myqZ7a6Sq1yZtR8+FVIvilVX66vF2uobSumxooYZChiRPCKNqhmg==}
     dev: true
+
+  /detect-indent@7.0.1:
+    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
+    engines: {node: '>=12.20'}
+    dev: false
 
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -2274,7 +2296,6 @@ packages:
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-    dev: true
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2786,7 +2807,6 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-    dev: true
 
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2947,7 +2967,6 @@ packages:
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: true
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,1 @@
+export * from './cli/index'

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -1,0 +1,51 @@
+import c from 'picocolors'
+import { version } from '../../package.json'
+
+export const ARROW = c.cyan('→')
+export const CHECK = c.green('✔')
+export const CROSS = c.red('✘')
+export const WARN = c.yellow('ℹ')
+
+export { version }
+
+export const vscodeSettingsString = `
+    // Enable the ESlint flat config support
+    "eslint.experimental.useFlatConfig": true,
+
+    // Disable the default formatter, use eslint instead
+    "prettier.enable": false,
+    "editor.formatOnSave": false,
+
+    // Auto fix
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit",
+        "source.organizeImports": "never"
+    },
+
+    // Silent the stylistic rules in you IDE, but still auto fix them
+    "eslint.rules.customizations": [
+        { "rule": "style/*", "severity": "off" },
+        { "rule": "*-indent", "severity": "off" },
+        { "rule": "*-spacing", "severity": "off" },
+        { "rule": "*-spaces", "severity": "off" },
+        { "rule": "*-order", "severity": "off" },
+        { "rule": "*-dangle", "severity": "off" },
+        { "rule": "*-newline", "severity": "off" },
+        { "rule": "*quotes", "severity": "off" },
+        { "rule": "*semi", "severity": "off" }
+    ],
+
+    // Enable eslint for all supported languages
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+        "vue",
+        "html",
+        "markdown",
+        "json",
+        "jsonc",
+        "yaml"
+    ]
+`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,21 @@
+import { cac } from 'cac'
+import c from 'picocolors'
+import { version } from './constants'
+import { migrate } from './migrate'
+
+const cli = cac(
+    c.green('@ivanmaxlogiudice/eslint-config'),
+)
+
+// Migrate
+cli
+    .command('migrate', 'Migrate from legacy config to new flat config')
+    .action(migrate)
+
+cli.help()
+cli.version(`${c.bold(version)}`)
+cli.parse()
+
+// Show the Help section if no command is given
+if (!cli.matchedCommand)
+    cli.outputHelp()

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,0 +1,161 @@
+/* eslint-disable no-console */
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import detectIndent from 'detect-indent'
+import parse from 'parse-gitignore'
+import c from 'picocolors'
+import prompts from 'prompts'
+import { ARROW, CHECK, CROSS, WARN, version, vscodeSettingsString } from './constants'
+import { isGitClean, throwError } from './utils'
+
+const SKIP_PROMPT = !!process.env.SKIP_PROMPT
+const SKIP_GIT_CHECK = !!process.env.SKIP_GIT_CHECK
+
+export async function migrate() {
+    const cwd = process.cwd()
+
+    const pathPackageJSON = path.join(process.cwd(), 'package.json')
+    const pathESLintConfig = path.join(process.cwd(), 'eslint.config.js')
+    const pathESLintIngore = path.join(process.cwd(), '.eslintignore')
+
+    if (fs.existsSync(pathESLintConfig))
+        throwError(WARN, 'eslint.config.js already exists, migration wizard exited.')
+
+    if (!SKIP_GIT_CHECK && !isGitClean())
+        throwError(CROSS, 'There are uncommitted changes in the current repository, please commit them and try again.')
+
+    // Update package.json
+    console.log(`\n${ARROW} Installing ${c.green('@ivanmaxlogiudice/eslint-config')} to v${c.yellow(version)}.\n`)
+
+    const pkgContent = await fsp.readFile(pathPackageJSON, 'utf-8')
+    const pkg: Record<string, any> = JSON.parse(pkgContent)
+
+    pkg.devDependencies ??= {}
+    pkg.devDependencies['@ivanmaxlogiudice/eslint-config'] = `^${version}`
+
+    await fsp.writeFile(pathPackageJSON, JSON.stringify(pkg, null, detectIndent(pkgContent).indent || 2))
+
+    console.log(`${CHECK} Changes wrote to package.json`)
+
+    // Get ESLint Ignores
+    const eslintIgnores: string[] = []
+    if (fs.existsSync(pathESLintIngore)) {
+        console.log(`${ARROW} Migrating existing .eslintignore.`)
+
+        const content = await fsp.readFile(pathESLintIngore, 'utf-8')
+        const parsed = parse(content)
+        const globs = parsed.globs()
+
+        for (const glob of globs) {
+            if (glob.type === 'ignore')
+                eslintIgnores.push(...glob.patterns)
+            else if (glob.type === 'unignore')
+                eslintIgnores.push(...glob.patterns.map((pattern: string) => `!${pattern}`))
+        }
+    }
+
+    // Create eslint.config.js
+    let configContent = `${eslintIgnores.length > 0 ? `ignores: ${JSON.stringify(eslintIgnores)}` : ''}`
+    if (pkg.type === 'module') {
+        configContent = `
+import config from '@ivanmaxlogiudice/eslint-config'
+
+export default config({\n${configContent}\n})
+`.trimStart()
+    }
+    else {
+        configContent = `
+const config = require('@ivanmaxlogiudice/eslint-config').default
+
+module.exports = config({\n${configContent}\n})
+`.trimStart()
+    }
+
+    await fsp.writeFile(pathESLintConfig, configContent)
+    console.log(`${CHECK} Created ${c.green('eslint.config.js')} successfully.`)
+
+    // List legacy files
+    const files = fs.readdirSync(cwd)
+    const legacyFiles: string[] = []
+
+    files.forEach((file) => {
+        if (file !== 'eslint.config.js' && (file.includes('eslint') || file.includes('prettier')))
+            legacyFiles.push(file)
+    })
+
+    if (legacyFiles.length > 0) {
+        console.log(`\n${WARN} You can now remove those files manually: `)
+        console.log(`  ${c.red('-')} ${c.dim(legacyFiles.join(', '))}`)
+    }
+
+    // List legacy dependencies
+    const dependencies = { ...pkg.devDependencies, ...pkg?.dependencies }
+    const legacyDependencies: string[] = []
+
+    Object.keys(dependencies).forEach((dep) => {
+        if (dep.includes('prettier'))
+            legacyDependencies.push(dep)
+    })
+
+    if (legacyDependencies.length > 0) {
+        console.log(`\n${WARN} You can now remove those dependencies: `)
+        console.log(`  ${c.red('-')} ${c.dim(legacyDependencies.join(', '))}`)
+    }
+
+    // Update .vscode/settings.json
+    let prompResult: prompts.Answers<'updateVscodeSettings'> = {
+        updateVscodeSettings: true,
+    }
+
+    if (!SKIP_PROMPT) {
+        console.log()
+
+        try {
+            prompResult = await prompts({
+                initial: true,
+                message: 'Update .vscode/settings.json for better VSCode experience?',
+                name: 'updateVscodeSettings',
+                type: 'confirm',
+            }, {
+                onCancel() {
+                    throw new Error('Cancelled')
+                },
+            })
+        }
+        catch (error: any) {
+            console.log(error.message)
+            return
+        }
+    }
+
+    if (prompResult.updateVscodeSettings ?? true) {
+        const dotVSCodePath = path.join(cwd, '.vscode')
+        const settingsPath = path.join(dotVSCodePath, 'settings.json')
+
+        if (!fs.existsSync(dotVSCodePath))
+            await fsp.mkdir(dotVSCodePath, { recursive: true })
+
+        if (!fs.existsSync(settingsPath)) {
+            await fsp.writeFile(settingsPath, `{${vscodeSettingsString}}\n`)
+
+            console.log(`${CHECK} Created ${c.green('.vscode/settings.json')} successfully.`)
+        }
+        else {
+            let settingsContent = await fsp.readFile(settingsPath, 'utf-8')
+
+            settingsContent = settingsContent.trim().replace(/\s*}$/, '')
+            settingsContent += settingsContent.endsWith(',') || settingsContent.endsWith('{') ? '' : ','
+            settingsContent += `${vscodeSettingsString}}\n`
+
+            await fsp.writeFile(settingsPath, settingsContent, 'utf-8')
+            console.log(`${CHECK} Updated ${c.green('.vscode/settings.json')} successfully.`)
+            console.log(`${WARN} You need to check if there is any conflict between duplicate keys.\n`)
+        }
+    }
+
+    // Migration completed
+    console.log(`${CHECK} Migration completed!`)
+    console.log(`${c.green('-')} Now you can update the dependencies and run ${c.blue('eslint . --fix')}\n`)
+}

--- a/src/cli/types.d.ts
+++ b/src/cli/types.d.ts
@@ -1,0 +1,2 @@
+// @types/parse-gitignore is outdated, so we need to declare this to avoid ts error.
+declare module 'parse-gitignore'

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process'
+import process from 'node:process'
+import c from 'picocolors'
+
+export function throwError(level: string, message: string) {
+    console.error(`\n${c.inverse(c.red(` Failed to migrate `))}`)
+    console.error(level, message)
+    process.exit(1)
+}
+
+export function isGitClean() {
+    try {
+        execSync('git diff-index --quiet HEAD --')
+        return true
+    }
+    catch {
+        return false
+    }
+}

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -3,11 +3,13 @@
 
 export { default as pluginStylistic } from '@stylistic/eslint-plugin'
 export { default as pluginTs } from '@typescript-eslint/eslint-plugin'
+
 /**
  * Parsers
  */
 export * as parserTs from '@typescript-eslint/parser'
 export { default as pluginUnocss } from '@unocss/eslint-plugin'
+
 /**
  * Plugins
  */

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,6 +3,7 @@ import process from 'node:process'
 import { execa } from 'execa'
 import fs from 'fs-extra'
 import { afterAll, beforeEach, expect, it } from 'vitest'
+import { devDependencies } from '../package.json'
 
 const CLI_PATH = join(__dirname, '../bin/index.js')
 const genPath = join(__dirname, '..', '.temp')
@@ -26,7 +27,7 @@ async function createMockDir() {
     await fs.ensureDir(genPath)
 
     await Promise.all([
-        fs.writeFile(join(genPath, 'package.json'), JSON.stringify({ devDependencies: { prettier: 'latest' } }, null, 2)),
+        fs.writeFile(join(genPath, 'package.json'), JSON.stringify({ devDependencies: { prettier: 'latest', eslint: '7.32.0' } }, null, 2)),
         fs.writeFile(join(genPath, '.eslintrc.yml'), ''),
         fs.writeFile(join(genPath, '.eslintignore'), 'some-path\nsome-file'),
         fs.writeFile(join(genPath, '.prettierc'), ''),
@@ -44,6 +45,15 @@ it('package.json updated', async () => {
 
     expect(JSON.stringify(pkgContent.devDependencies)).toContain('@ivanmaxlogiudice/eslint-config')
     expect(stdout).toContain('Changes wrote to package.json')
+})
+
+it('update eslint version', async () => {
+    const { stdout } = await run()
+
+    const pkgContent: Record<string, any> = await fs.readJSON(join(genPath, 'package.json'))
+
+    expect(pkgContent.devDependencies.eslint).toBe(devDependencies.eslint)
+    expect(stdout).toContain('Updated eslint to the version')
 })
 
 it('esm eslint.config.js', async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,97 @@
+import { join } from 'node:path'
+import process from 'node:process'
+import { execa } from 'execa'
+import fs from 'fs-extra'
+import { afterAll, beforeEach, expect, it } from 'vitest'
+
+const CLI_PATH = join(__dirname, '../bin/index.js')
+const genPath = join(__dirname, '..', '.temp')
+
+function run(env = {
+    SKIP_PROMPT: '1',
+    SKIP_GIT_CHECK: '1',
+}) {
+    return execa(`node`, [CLI_PATH, 'migrate'], {
+        cwd: genPath,
+        env: {
+            ...process.env,
+            NO_COLOR: '1',
+            ...env,
+        },
+    })
+};
+
+async function createMockDir() {
+    await fs.rm(genPath, { recursive: true, force: true })
+    await fs.ensureDir(genPath)
+
+    await Promise.all([
+        fs.writeFile(join(genPath, 'package.json'), JSON.stringify({ devDependencies: { prettier: 'latest' } }, null, 2)),
+        fs.writeFile(join(genPath, '.eslintrc.yml'), ''),
+        fs.writeFile(join(genPath, '.eslintignore'), 'some-path\nsome-file'),
+        fs.writeFile(join(genPath, '.prettierc'), ''),
+        fs.writeFile(join(genPath, '.prettierignore'), 'some-path\nsome-file'),
+    ])
+};
+
+beforeEach(async () => await createMockDir())
+afterAll(async () => await fs.rm(genPath, { force: true, recursive: true }))
+
+it('package.json updated', async () => {
+    const { stdout } = await run()
+
+    const pkgContent: Record<string, any> = await fs.readJSON(join(genPath, 'package.json'))
+
+    expect(JSON.stringify(pkgContent.devDependencies)).toContain('@ivanmaxlogiudice/eslint-config')
+    expect(stdout).toContain('Changes wrote to package.json')
+})
+
+it('esm eslint.config.js', async () => {
+    const pkgContent = await fs.readFile('package.json', 'utf-8')
+    await fs.writeFile(join(genPath, 'package.json'), JSON.stringify({ ...JSON.parse(pkgContent), type: 'module' }, null, 2))
+
+    const { stdout } = await run()
+
+    const eslintConfigContent = await fs.readFile(join(genPath, 'eslint.config.js'), 'utf-8')
+    expect(eslintConfigContent.includes('export default')).toBeTruthy()
+    expect(stdout).toContain('Created eslint.config.js successfully.')
+})
+
+it('cjs eslint.config.js', async () => {
+    const { stdout } = await run()
+
+    const eslintConfigContent = await fs.readFile(join(genPath, 'eslint.config.js'), 'utf-8')
+    expect(eslintConfigContent.includes('module.exports')).toBeTruthy()
+    expect(stdout).toContain('Created eslint.config.js successfully.')
+})
+
+it('ignores files added in eslint.config.js', async () => {
+    const { stdout } = await run()
+
+    const eslintConfigContent = (await fs.readFile(join(genPath, 'eslint.config.js'), 'utf-8')).replaceAll('\\', '/')
+
+    expect(stdout).toContain('Created eslint.config.js successfully.')
+    expect(eslintConfigContent)
+        .toMatchInlineSnapshot(`
+      "const config = require('@ivanmaxlogiudice/eslint-config').default
+
+      module.exports = config({
+      ignores: [\\"some-path\\",\\"**/some-path/**\\",\\"some-file\\",\\"**/some-file/**\\"]
+      })
+      "
+    `)
+})
+
+it('suggest remove unnecessary files', async () => {
+    const { stdout } = await run()
+
+    expect(stdout).toContain('You can now remove those files manually:')
+    expect(stdout).toContain('- .eslintignore, .eslintrc.yml, .prettierc, .prettierignore')
+})
+
+it('suggest remove unnecessary dependencies', async () => {
+    const { stdout } = await run()
+
+    expect(stdout).toContain('You can now remove those dependencies:')
+    expect(stdout).toContain('- prettier')
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ESNext",
-        "lib": ["ESNext"],
+        "lib": ["ES2022"],
         "baseUrl": ".",
         "module": "ESNext",
         "moduleResolution": "Bundler",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    entry: [
+        'src/index.ts',
+        'src/cli.ts',
+    ],
+    shims: true,
+})


### PR DESCRIPTION
CLI:
- Install the latest version of `@ivanmaxlogiudice/eslint-config` to `devDependencies`
- Create `eslint.config.js` file, add the new config and migrate `.eslintignore` to it if there is one.
- Suggest remove all legacy files (.eslintignore, .eslintrc.yml, .prettierc, .prettierignore, ...).
- Suggest remove all legacy dependencies (prettier, eslint-plugin-prettier, ...).
- Adds/update `.vscode/settings.json` to the configuration that was provided in `README.md`.
- Adds/update `eslint` to the current version of this config.

INFO:
- If there already exists an `eslint.config.js` file the migration is cancelled.
- If there are uncommitted changes in the repository, the migration is cancelled.